### PR TITLE
fix(bin/leanpkg): handle spaces in paths on POSIX systems

### DIFF
--- a/bin/leanpkg
+++ b/bin/leanpkg
@@ -14,12 +14,12 @@ else
     READLINK=readlink
 fi
 
-leandir=$(dirname $($READLINK -f $0))/..
-leandir=$($READLINK -f $leandir)
+leandir=$(dirname "$($READLINK -f "$0")")/..
+leandir=$($READLINK -f "$leandir")
 
 librarydir="$leandir/lib/lean"
 test -d "$librarydir" || librarydir="$leandir"
 
 LEAN_PATH=$librarydir/library:$librarydir/leanpkg \
   PATH=$leandir/bin:$PATH \
-  exec lean --run $librarydir/leanpkg/leanpkg/main.lean "$@"
+  exec lean --run "$librarydir/leanpkg/leanpkg/main.lean" "$@"


### PR DESCRIPTION
All these quotes are necessary (and sufficient) when the path containing `leanpkg` has a space.